### PR TITLE
Added option for local playback

### DIFF
--- a/src/main/java/org/droidupnp/view/ContentDirectoryFragment.java
+++ b/src/main/java/org/droidupnp/view/ContentDirectoryFragment.java
@@ -202,64 +202,64 @@ public class ContentDirectoryFragment extends ListFragment implements Observer
 			contentDirectoryCommand = Main.factory.createContentDirectoryCommand();
 		}
 
-        getListView().setOnItemLongClickListener( new AdapterView.OnItemLongClickListener() {
-            @Override
-            public boolean onItemLongClick(AdapterView<?> adapterView, View v, int position, long id) {
-                Log.v(TAG, "On long-click event");
+		getListView().setOnItemLongClickListener( new AdapterView.OnItemLongClickListener() {
+			@Override
+			public boolean onItemLongClick(AdapterView<?> adapterView, View v, int position, long id) {
+				Log.v(TAG, "On long-click event");
 
-                IDIDLObject didl = contentList.getItem(position).getDIDLObject();
+				IDIDLObject didl = contentList.getItem(position).getDIDLObject();
 
-                if (didl instanceof IDIDLItem)
-                {
-                    IDIDLItem ididlItem = (IDIDLItem) didl;
-                    final Activity a = getActivity();
-                    final Intent intent = new Intent(Intent.ACTION_VIEW);
+				if (didl instanceof IDIDLItem)
+				{
+					IDIDLItem ididlItem = (IDIDLItem) didl;
+					final Activity a = getActivity();
+					final Intent intent = new Intent(Intent.ACTION_VIEW);
 
-                    Uri uri = Uri.parse(ididlItem.getURI());
+					Uri uri = Uri.parse(ididlItem.getURI());
 
-                    if (didl instanceof ClingAudioItem)
-                        intent.setDataAndType(uri, "audio/*");
+					if (didl instanceof ClingAudioItem)
+						intent.setDataAndType(uri, "audio/*");
 
-                    if (didl instanceof ClingVideoItem)
-                        intent.setDataAndType(uri, "video/*");
+					if (didl instanceof ClingVideoItem)
+						intent.setDataAndType(uri, "video/*");
 
-                    // A image from the network can't be viewed using any of android's stock apps.
-                    // See:
-                    // https://stackoverflow.com/questions/7734432/use-android-intent-to-display-an-image-from-internet
-                    // This is only here in case it works in the future.
-                    if (didl instanceof ClingImageItem)
-                        intent.setDataAndType(uri, "image/*");
+					// A image from the network can't be viewed using any of android's stock apps.
+					// See:
+					// https://stackoverflow.com/questions/7734432/use-android-intent-to-display-an-image-from-internet
+					// This is only here in case it works in the future.
+					if (didl instanceof ClingImageItem)
+						intent.setDataAndType(uri, "image/*");
 
-                    final String launch_local_viewer = getResources().getString(R.string.launch_local_viewer);
-                    final String nothing_on_device_can_open_item = getResources().getString(R.string.nothing_on_device_can_open_item);
+					final String launch_local_viewer = getResources().getString(R.string.launch_local_viewer);
+					final String nothing_on_device_can_open_item = getResources().getString(R.string.nothing_on_device_can_open_item);
 
-                    AlertDialog.Builder builder = new AlertDialog.Builder(a);
-                    CharSequence[] list = new CharSequence[1];
-                    list[0] = launch_local_viewer;
-                    builder.setItems(list, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialogInterface, int i) {
-                            try {
-                                a.startActivity(intent);
-                            }
-                            catch (ActivityNotFoundException ex) {
-                                Toast.makeText(getActivity(), nothing_on_device_can_open_item, Toast.LENGTH_SHORT).show();
-                            }
-                        }
-                    });
-                    AlertDialog dialog = builder.create();
-                    dialog.show();
+					AlertDialog.Builder builder = new AlertDialog.Builder(a);
+					CharSequence[] list = new CharSequence[1];
+					list[0] = launch_local_viewer;
+					builder.setItems(list, new DialogInterface.OnClickListener() {
+						@Override
+						public void onClick(DialogInterface dialogInterface, int i) {
+							try {
+								a.startActivity(intent);
+							}
+							catch (ActivityNotFoundException ex) {
+								Toast.makeText(getActivity(), nothing_on_device_can_open_item, Toast.LENGTH_SHORT).show();
+							}
+						}
+					});
+					AlertDialog dialog = builder.create();
+					dialog.show();
 
-                    return true;
-                }
-                else
-                {
-                    Toast.makeText(getActivity(), "No action available", Toast.LENGTH_SHORT).show();
-                }
+					return true;
+				}
+				else
+				{
+					Toast.makeText(getActivity(), "No action available", Toast.LENGTH_SHORT).show();
+				}
 
-                return true;
-            }
-        });
+				return true;
+			}
+		});
 
 		Log.d(TAG, "Force refresh");
 		refresh();

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -63,9 +63,9 @@
 	<string name="noRenderer">There is no renderer available</string>
 	<string name="selectContentDirectory">Select a Content directory</string>
 
-    <!-- Long click options -->
-    <string name="launch_local_viewer">Launch local viewer</string>
-    <string name="nothing_on_device_can_open_item">Nothing on your device can view/open this item</string>
+	<!-- Long click options -->
+	<string name="launch_local_viewer">Launch local viewer</string>
+	<string name="nothing_on_device_can_open_item">Nothing on your device can view/open this item</string>
 
 	<!-- Now Playing -->
 	<string name="duration">00:00:00</string>


### PR DESCRIPTION
This is a solution for issue #31

Long press on a item will show the option "Launch local viewer":
-  remote/local music items will launch the default music player and play it
-  remote/local video items will launch the default video player and play it
-  remote pictures will NOT work, not supported using android apps
-  local pictures will launch the default picture viewer

Long press on a directory result in a toast: "No action available"
