### PR TITLE
subtitle support, tested with xbmc/kodi

### DIFF
--- a/src/main/java/org/droidupnp/controller/cling/RendererCommand.java
+++ b/src/main/java/org/droidupnp/controller/cling/RendererCommand.java
@@ -42,6 +42,7 @@ import org.fourthline.cling.support.avtransport.callback.Stop;
 import org.fourthline.cling.support.model.DIDLObject;
 import org.fourthline.cling.support.model.MediaInfo;
 import org.fourthline.cling.support.model.PositionInfo;
+import org.fourthline.cling.support.model.Res;
 import org.fourthline.cling.support.model.TransportInfo;
 import org.fourthline.cling.support.model.item.AudioItem;
 import org.fourthline.cling.support.model.item.ImageItem;
@@ -55,6 +56,8 @@ import org.fourthline.cling.support.renderingcontrol.callback.SetMute;
 import org.fourthline.cling.support.renderingcontrol.callback.SetVolume;
 
 import android.util.Log;
+
+import java.util.ArrayList;
 
 @SuppressWarnings("rawtypes")
 public class RendererCommand implements Runnable, IRendererCommand {
@@ -319,11 +322,14 @@ public class RendererCommand implements Runnable, IRendererCommand {
 			type = "playlistItem";
 		else if (upnpItem instanceof TextItem)
 			type = "textItem";
-
+        ArrayList<TrackMetadata.Resource> reslist= new ArrayList<>();
+        for(Res r:upnpItem.getResources()){
+            String pi = r.getProtocolInfo()==null?null: r.getProtocolInfo().toString();
+            reslist.add(new TrackMetadata.Resource(r.getValue(),pi));
+        }
 		// TODO genre && artURI
 		final TrackMetadata trackMetadata = new TrackMetadata(upnpItem.getId(), upnpItem.getTitle(),
-				upnpItem.getCreator(), "", "", upnpItem.getFirstResource().getValue(),
-				"object.item." + type);
+				upnpItem.getCreator(), "", "", "object.item." + type,reslist);
 
 		Log.i(TAG, "TrackMetadata : "+trackMetadata.toString());
 


### PR DESCRIPTION
Works seamlessly in my environment (serviio-xbmc on raspberry pi, needs a recentish kodi build, mine is 13.2).
it's not minimal: I could have added a single subtitle resource and two protocolinfo (as soon as you have more than a <res> node you need that to classify them) but I thought this would be more flexible (i.e. support multiple subtitle streams).
After stopping the subtitle info is lost, couldn't understand how to fix that: I reckon the issue is that cling doesn't return current position metadata, the only workaround I can think of is to store it but looks a bit too invasive.
Pausing and seeking work fine.
